### PR TITLE
Error handling: enhance exception messages

### DIFF
--- a/src/main/java/tech/sourced/siva/IndexReader.java
+++ b/src/main/java/tech/sourced/siva/IndexReader.java
@@ -12,9 +12,11 @@ public class IndexReader {
     private static final byte[] INDEX_SIGNATURE = {'I', 'B', 'A'};
 
     private final RandomAccessFile sivaFile;
+    private final String sivaFileName;
 
-    IndexReader(RandomAccessFile sivaFile) {
+    IndexReader(RandomAccessFile sivaFile, String sivaFileName) {
         this.sivaFile = sivaFile;
+        this.sivaFileName = sivaFileName;
     }
 
     /**
@@ -67,7 +69,7 @@ public class IndexReader {
 
             return index;
         } catch (IOException e) {
-            throw new SivaException("Error reading index", e);
+            throw new SivaException("Error reading index of " + this.sivaFileName + " file.", e);
         }
     }
 
@@ -110,7 +112,7 @@ public class IndexReader {
     private void readIndexVersion() throws IOException, SivaException {
         int version = this.sivaFile.readByte();
         if (version != INDEX_VERSION) {
-            throw new SivaException("invalid index version");
+            throw new SivaException("Invalid index version at " + this.sivaFileName + " file.");
         }
     }
 
@@ -118,7 +120,7 @@ public class IndexReader {
         byte[] sig = new byte[3];
         this.sivaFile.readFully(sig);
         if (!Arrays.equals(sig, INDEX_SIGNATURE)) {
-            throw new SivaException("invalid index signature");
+            throw new SivaException("Invalid index signature at " + this.sivaFileName + " file.");
         }
     }
 }

--- a/src/main/java/tech/sourced/siva/SivaReader.java
+++ b/src/main/java/tech/sourced/siva/SivaReader.java
@@ -14,6 +14,7 @@ import java.nio.channels.FileChannel;
 public class SivaReader {
 
     private final RandomAccessFile sivaFile;
+    private final String sivaFileName;
     private final FileChannel channel;
 
     /**
@@ -24,6 +25,7 @@ public class SivaReader {
      */
     public SivaReader(File sivaFile) throws FileNotFoundException {
         this.sivaFile = new RandomAccessFile(sivaFile, "r");
+        this.sivaFileName = sivaFile.getName();
         this.channel = this.sivaFile.getChannel();
     }
 
@@ -56,7 +58,7 @@ public class SivaReader {
      * @return an {@link IndexReader}
      */
     public IndexReader getIndex() {
-        return new IndexReader(this.sivaFile);
+        return new IndexReader(this.sivaFile, this.sivaFileName);
     }
 
     /**


### PR DESCRIPTION
IO exceptions now include the file name, causing it.

I.e before, one could get `tech.sourced.siva.SivaException: invalid index signature` and spend some time, figuring out that it has been due to `siva.tar` file present in repositories path.

Now that will be `tech.sourced.siva.SivaException: Invalid index signature at siva.tar file.`